### PR TITLE
feat: add explicit pickDirectory() ios implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Requires RN >= 0.63, Android 5.0+ and iOS 11+
   - [RN &gt;= 0.63](#rn--063)
   - [API](#api)
     - [DocumentPicker.pickMultiple(options) / DocumentPicker.pickSingle(options) / DocumentPicker.pick(options)](#documentpickerpickmultipleoptions--documentpickerpicksingleoptions--documentpickerpickoptions)
-    - [[Android and Windows only] DocumentPicker.pickDirectory()](#android-and-windows-only-documentpickerpickdirectory)
+    - [DocumentPicker.pickDirectory()](#documentpickerpickdirectory)
     - [DocumentPicker.pick(options) and DocumentPicker.pickMultiple(options)](#documentpickerpickoptions-and-documentpickerpickmultipleoptions)
     - [Options](#options)
       - [allowMultiSelection:boolean](#allowmultiselectionboolean)
@@ -73,7 +73,7 @@ If you are using RN >= 0.63, only run `pod install` from the ios directory. Then
 
 Use `pickMultiple`, `pickSingle` or `pick` to open a document picker for the user to select file(s). All methods return a Promise.
 
-#### [Android and Windows only] `DocumentPicker.pickDirectory()`
+#### `DocumentPicker.pickDirectory()`
 
 Open a system directory picker. Returns a promise that resolves to (`{ uri: string }`) of the directory selected by user.
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -83,7 +83,7 @@ export default function App() {
         }}
       />
       <Button
-        title="open directory picker (android+windows only)"
+        title="open directory picker"
         onPress={() => {
           DocumentPicker.pickDirectory().then(setResult).catch(handleError)
         }}

--- a/ios/RNDocumentPicker.m
+++ b/ios/RNDocumentPicker.m
@@ -7,6 +7,7 @@
 #import <React/RCTUtils.h>
 #import "RNCPromiseWrapper.h"
 
+
 static NSString *const E_DOCUMENT_PICKER_CANCELED = @"DOCUMENT_PICKER_CANCELED";
 static NSString *const E_INVALID_DATA_RETURNED = @"INVALID_DATA_RETURNED";
 
@@ -87,7 +88,8 @@ RCT_EXPORT_METHOD(pick:(NSDictionary *)options
     [promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject fromCallSite:@"pick"];
 
     NSArray *allowedUTIs = [RCTConvert NSArray:options[OPTION_TYPE]];
-    UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:(NSArray *)allowedUTIs inMode:mode];
+    UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:allowedUTIs inMode:mode];
+
     documentPicker.modalPresentationStyle = presentationStyle;
 
     documentPicker.delegate = self;
@@ -126,6 +128,7 @@ RCT_EXPORT_METHOD(pick:(NSDictionary *)options
         [urlsInOpenMode addObject:url];
     }
     
+    // TODO handle error
     [url startAccessingSecurityScopedResource];
 
     NSFileCoordinator *coordinator = [NSFileCoordinator new];
@@ -158,7 +161,7 @@ RCT_EXPORT_METHOD(pick:(NSDictionary *)options
         }
 
         if (newURL.pathExtension != nil) {
-            CFStringRef extension = (__bridge CFStringRef)[newURL pathExtension];
+            CFStringRef extension = (__bridge CFStringRef) newURL.pathExtension;
             CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, extension, NULL);
             CFStringRef mimeType = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType);
             if (uti) {
@@ -238,7 +241,8 @@ RCT_EXPORT_METHOD(releaseSecureAccess:(NSArray<NSString *> *)uris
     [self rejectAsUserCancellationError];
 }
 
-- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+{
     [self rejectAsUserCancellationError];
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,12 +36,19 @@ export type DocumentPickerOptions<OS extends SupportedPlatforms> = {
   allowMultiSelection?: boolean
 } & Pick<ModalPropsIOS, 'presentationStyle'>
 
-export function pickDirectory(): Promise<DirectoryPickerResponse | null> {
-  if (Platform.OS === 'android' || Platform.OS === 'windows') {
-    return RNDocumentPicker.pickDirectory()
+export async function pickDirectory<OS extends SupportedPlatforms>(
+  params?: Pick<DocumentPickerOptions<OS>, 'presentationStyle'>,
+): Promise<DirectoryPickerResponse | null> {
+  if (Platform.OS === 'ios') {
+    const result = await pick({
+      ...params,
+      mode: 'open',
+      allowMultiSelection: false,
+      type: ['public.folder'],
+    })
+    return { uri: result[0].uri }
   } else {
-    // TODO iOS impl
-    return Promise.resolve(null)
+    return RNDocumentPicker.pickDirectory()
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Previously, `pickDirectory()` was not written for ios; this PR adds implementation of that method

## Test Plan

tested on ios emulator using the example app

### What's required for testing (prerequisites)?

run the example app

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
