### PR TITLE
fix: link MobileCoreServices to resolve undefined symbols error on build

### DIFF
--- a/react-native-document-picker.podspec
+++ b/react-native-document-picker.podspec
@@ -18,6 +18,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
+
+  s.frameworks   = 'MobileCoreServices'
   
   # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/react-native-document-picker.podspec
+++ b/react-native-document-picker.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
 
-  s.frameworks   = 'MobileCoreServices'
+  s.frameworks = 'MobileCoreServices'
   
   # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
This PR fixes a build error related to undefined symbols from MobileCoreServices by linking the MobileCoreServices framework in the podspec

This PR solves issue #713 and issue #685 