### PR TITLE
fix(android): Migrate away from onCatalystInstanceDestroy() to invalidate

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/RNDocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/RNDocumentPickerModule.java
@@ -103,9 +103,9 @@ public class RNDocumentPickerModule extends NativeDocumentPickerSpec {
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     getReactApplicationContext().removeActivityEventListener(activityEventListener);
-    super.onCatalystInstanceDestroy();
+    super.invalidate();
   }
 
   @NonNull


### PR DESCRIPTION
Since NativeModule.onCatalystInstanceDestroy() method as deprecated and remove  in new architecture.

(https://github.com/facebook/react-native/commit/18c8417290823e67e211bde241ae9dde27b72f17