### PR TITLE
fix(ios): picker cancelled error code to match JS expected value

### DIFF
--- a/.changeset/kind-trains-smoke.md
+++ b/.changeset/kind-trains-smoke.md
@@ -1,0 +1,5 @@
+---
+"@react-native-documents/picker": patch
+---
+
+Fix iOS picker cancelled error code to match JS expected value

--- a/packages/document-picker/ios/swift/PromiseWrapper.swift
+++ b/packages/document-picker/ios/swift/PromiseWrapper.swift
@@ -7,7 +7,7 @@ class PromiseWrapper {
   private var promiseReject: RNDPPromiseRejectBlock?
   private var nameOfCallInProgress: String?
 
-  private let E_DOCUMENT_PICKER_CANCELED = "E_DOCUMENT_PICKER_CANCELED"
+  private let E_DOCUMENT_PICKER_CANCELED = "OPERATION_CANCELED"
   private let ASYNC_OP_IN_PROGRESS = "ASYNC_OP_IN_PROGRESS"
 
   func setPromiseRejectingPrevious(_ resolve: @escaping RNDPPromiseResolveBlock,


### PR DESCRIPTION
Calling `pick` and then cancelling the picker on iOS will currently throw an error with the code `"E_DOCUMENT_PICKER_CANCELED"`, however it should be throwing with the code `"OPERATION_CANCELED"` to match Android and match the expected value in the JS error codes constant.

JS error codes: https://github.com/react-native-documents/document-picker/blob/74dcb94eb19a748fc61a9916aec127975e19c139/packages/document-picker/src/errors.ts#L5-L39

Android error codes: https://github.com/react-native-documents/document-picker/blob/74dcb94eb19a748fc61a9916aec127975e19c139/packages/document-picker/android/src/main/java/com/reactnativedocumentpicker/PromiseWrapper.java#L14-L15