### PR TITLE
chore: cleaner podspec

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -7,10 +7,12 @@ on:
     paths:
       - '.github/workflows/ios.yml'
       - 'packages/**/ios**'
+      - 'packages/**/*.podspec'
   pull_request:
     paths:
       - '.github/workflows/ios.yml'
       - 'packages/**/ios**'
+      - 'packages/**/*.podspec'
 
 jobs:
   ios-build:

--- a/packages/document-picker/react-native-document-picker.podspec
+++ b/packages/document-picker/react-native-document-picker.podspec
@@ -21,9 +21,5 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
   }
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    install_modules_dependencies(s)
-  else
-    s.dependency "React-Core"
-  end
+  install_modules_dependencies(s)
 end

--- a/packages/document-viewer/react-native-document-viewer.podspec
+++ b/packages/document-viewer/react-native-document-viewer.podspec
@@ -16,10 +16,5 @@ Pod::Spec.new do |s|
 
   s.source_files = ["ios/**/*.{h,m,mm}"]
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    # RN 71+
-    install_modules_dependencies(s)
-  else
-    s.dependency "React-Core"
-  end
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
`install_modules_dependencies` is available on RN 0.71+ which is old enough, and it's available for both old and new arch