### PR TITLE
refactor: copy streams differently

### DIFF
--- a/.changeset/twenty-bikes-hunt.md
+++ b/.changeset/twenty-bikes-hunt.md
@@ -1,0 +1,5 @@
+---
+"@react-native-documents/picker": patch
+---
+
+refactor: copy streams differently


### PR DESCRIPTION
- reuse the same, more conservative but proven method of stream copying in `keepLocalCopy` and in `saveDocuments`
- in case of copying between `File*Stream`s , this method should be more efficient on Android >=10